### PR TITLE
fix rais 3.2.2  LoadError (cannot load such file -- google/api_client

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 gem 'working_hours'
 gem 'holidays'
 gem 'slack-api', git: 'https://github.com/aki017/slack-ruby-gem.git'
-gem 'google-api-client'
+gem 'google-api-client', '~> 0.7.1'


### PR DESCRIPTION
it will fix similar issue to https://github.com/google/google-api-ruby-client/issues/132